### PR TITLE
Add `Package.swift` for Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,52 @@
+// swift-tools-version:5.5
+
+import PackageDescription
+
+let package = Package(
+    name: "ServiceSDK-iOS",
+    products: [
+        .library(
+            name: "ServiceCases",
+            targets: [
+                "ServiceCases",
+                "ServiceCore",
+            ]
+        ),
+        .library(
+            name: "ServiceChat",
+            targets: [
+                "ServiceChat",
+                "ServiceCore",
+            ]
+        ),
+        .library(
+            name: "ServiceKnowledge",
+            targets: [
+                "ServiceKnowledge",
+                "ServiceCore",
+            ]
+        ),
+    ],
+    targets: [
+        .binaryTarget(
+            name: "ServiceCore",
+            url: "https://dfc-data-production.s3.amazonaws.com/files/service_sdk_ios/234.1.0/ServiceCore-234.1.0.zip",
+            checksum: ""
+        ),
+        .binaryTarget(
+            name: "ServiceCases",
+            url: "https://dfc-data-production.s3.amazonaws.com/files/service_sdk_ios/234.1.0/ServiceCases-234.1.0.zip",
+            checksum: ""
+        ),
+        .binaryTarget(
+            name: "ServiceChat",
+            url: "https://dfc-data-production.s3.amazonaws.com/files/service_sdk_ios/234.1.0/ServiceChat-234.1.0.zip",
+            checksum: ""
+        ),
+        .binaryTarget(
+            name: "ServiceKnowledge",
+            url: "https://dfc-data-production.s3.amazonaws.com/files/service_sdk_ios/234.1.0/ServiceKnowledge-234.1.0.zip",
+            checksum: ""
+        ),
+    ]
+)


### PR DESCRIPTION
It would be great if this library had easy SPM support. Being the libraries are already setup as XCFrameworks, it shouldn't be too difficult. I've included an example `Package.swift` file that I believe would do the trick.

The URLs in the file aren't real obviously. The frameworks would have to be re-uploaded — SPM requires that xcframeworks are individually zipped, and exist at the root of the zip file — but hopefully that isn't too much work.

This would go a long way toward making the libraries easier to work with by developers. Please consider!